### PR TITLE
Fix repeated page names on sidebar

### DIFF
--- a/build/index.php
+++ b/build/index.php
@@ -2068,9 +2068,6 @@ function render_sidebar($pageindex, $root_pagename = "")
 		if($pagename == $root_pagename)
 			continue;
 		
-		// If the page already appears on the sidebar, skip it
-		if(preg_match("/>$pagename<\a>/m",$result)===1)
-			continue;
 		
 		// If the part of the current pagename that comes after the root
 		// pagename has a slash in it, skip it as it is a sub-sub page.

--- a/build/index.php
+++ b/build/index.php
@@ -2068,6 +2068,9 @@ function render_sidebar($pageindex, $root_pagename = "")
 		if($pagename == $root_pagename)
 			continue;
 		
+		// If the page already appears on the sidebar, skip it
+		if(preg_match("/>$pagename<\a>/m",$result)===1)
+			continue;
 		
 		// If the part of the current pagename that comes after the root
 		// pagename has a slash in it, skip it as it is a sub-sub page.

--- a/modules/extra-sidebar.php
+++ b/modules/extra-sidebar.php
@@ -100,7 +100,10 @@ function render_sidebar($pageindex, $root_pagename = "")
 		// The current page is the same as the root page, skip it
 		if($pagename == $root_pagename)
 			continue;
-		
+
+		// If the page already appears on the sidebar, skip it
+		if(preg_match("/>$pagename<\a>/m",$result)===1)
+			continue;		
 		
 		// If the part of the current pagename that comes after the root
 		// pagename has a slash in it, skip it as it is a sub-sub page.


### PR DESCRIPTION
For cases like this, pages appear twice on the sidebar:
![image](https://cloud.githubusercontent.com/assets/12506147/26530974/e78aa2c0-4394-11e7-900e-2db1013da9f5.png)

Added code to check if page already appears in sidebar.  If so, continue the loop, keeping the page from appearing twice.