### PR TITLE
Fix undefined var when posting new top-level comment

### DIFF
--- a/modules/feature-comments.php
+++ b/modules/feature-comments.php
@@ -134,7 +134,7 @@ register_module([
 					"timestamp" => time(),
 					"page" => $env->page,
 					"user" => $env->user,
-					"reply_depth" => $comment_thread !== null ? count($comment_thread) : 0,
+					"reply_depth" => isset($comment_thread) ? count($comment_thread) : 0,
 					"comment_id" => $new_comment->id
 				]);
 			}


### PR DESCRIPTION
Hello! Here's a small patch for you to consider.

With 0.24, when I post a comment that's not a reply, if the recent_changes module is enabled, I see the following PHP warning and the automatic redirect to my posted comment doesn't work.

```
Warning: Undefined variable $comment_thread in /usr/local/www/wiki/index.php on line 3956
```

This PR fixes the issue. I've tested it on FreeBSD with Apache and PHP 8.0, 8.1, and 8.2.

Thank you for all your work on Pepperminty Wiki—what a fabulous bit of software! 

I agree to release this contribution under the Mozilla Public License 2.0.