### PR TITLE
Fixes to deprecation warnings starting in PHP 8.2

### DIFF
--- a/modules/lib-search-engine.php
+++ b/modules/lib-search-engine.php
@@ -831,8 +831,9 @@ class search
 				continue; // Skip terms we shouldn't search the page body for
 			
 			// Loop over the pageindex and search the titles / tags
-			reset($pageindex); // Reset array/object pointer
-			foreach($pageindex as $pagename => $pagedata) {
+			$obj = new ArrayObject($pageindex);
+			$it = $obj->getIterator();
+			foreach($it as $pagename => $pagedata) {
 				// Setup a variable to hold the current page's id
 				$pageid = null; // Cache the page id
 				

--- a/modules/parser-parsedown.php
+++ b/modules/parser-parsedown.php
@@ -1101,9 +1101,9 @@ class PeppermintParsedown extends ParsedownExtra
 		// The page name is made safe when Pepperminty Wiki does initial consistency checks (if it's unsafe it results in a 301 redirect)
 		$page_name = parsedown_pagename_resolve($matches_url[1]);
 		
-		$internal_link_text = "[[${page_name}]]";
+		$internal_link_text = "[[{$page_name}]]";
 		if(!empty($matches[1])) // If the display text isn't empty, then respect it
-			$internal_link_text = "[[${page_name}¦{$matches[1]}]]";
+			$internal_link_text = "[[{$page_name}¦{$matches[1]}]]";
 		
 		$result = $this->inlineInternalLink([
 			"text" => $internal_link_text


### PR DESCRIPTION
Hello! Another patch for you to consider. This PR updates a few lines that still work but cause deprecation warnings starting in PHP 8.2. 

The first commit replaces `${var}` with `{$var}`. The second uses an iterator instead of calling `reset()` on an object. I've validated them on FreeBSD with Apache and PHP 8.0, 8.1, and 8.2.

I followed the guidance in the deprecation notices but don't have much experience with PHP—happy to change or rework based on your feedback. Thank you so much!

I agree to release this contribution under the Mozilla Public License 2.0.